### PR TITLE
update requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "2.6"
-  - "3.2"
+  - "2.7"
+  - "3.3"
   - "nightly"
 script: python test.py

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Rabbit in Python
 
+Current minimum requirements: Python 2.7.x or 3.3+
+
 ## Installation
 
 You can include rabbit.py directly:

--- a/rabbit.py
+++ b/rabbit.py
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 # Rabbit-Converter/Rabbit-Python
 # Zawgyi <-> Unicode converter for Myanmar language
 

--- a/test.py
+++ b/test.py
@@ -1,4 +1,4 @@
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 # test.py for Rabbit-Python
 
 import unittest


### PR DESCRIPTION
it looks like the errors in Travis CI were mostly because of Regex bugs in old Python versions. This updates the Python versions and puts the minimum requirements (2.7.x, 3.3+) in the README
